### PR TITLE
ブラウザバック時のスクロールポジション変更

### DIFF
--- a/app/javascript/packs/components/BeerInfo.jsx
+++ b/app/javascript/packs/components/BeerInfo.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { useState } from "react";
+import React, { useState, useLayoutEffect } from "react";
 import { useLocation } from "react-router-dom";
 import PropTypes from "prop-types";
 import CameraSearch from "./CameraSearch";
@@ -7,8 +6,12 @@ import Grid from "@material-ui/core/Grid";
 import { Oval } from  "react-loader-spinner";
 
 const BeerInfo = () => {
-  const { state } = useLocation();
+  const { state, pathname } = useLocation();
   console.log(state);
+
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
 
   return (
     <>

--- a/app/javascript/packs/store/beerSearchResultsState.js
+++ b/app/javascript/packs/store/beerSearchResultsState.js
@@ -2,5 +2,8 @@ import { atom } from "recoil";
 
 export const beerSearchResultsState = atom({
   key: "beerSearchResultsState",
-  default: { params: "", beers: [] }
+  default: {
+    params: "",
+    beers: []
+  }
 });

--- a/app/javascript/packs/store/scrollPositionState.js
+++ b/app/javascript/packs/store/scrollPositionState.js
@@ -1,0 +1,9 @@
+import { atom } from "recoil";
+
+export const scrollPositionState = atom({
+  key: "scrollPositionState",
+  default: {
+    params: "",
+    scrollY: ""
+  }
+});


### PR DESCRIPTION
- ブラウザバックした時に元のスクロール位置に戻るように実装
   - 詳細ページ遷移時にURLに``#back``を付与 & storeにパラメータとスクロールポジションを保存
   - URLのハッシュクエリとstoreのパタメータ/現在のパラメータを照合し、ブラウザバックを検知
   - ブラウザバックの時のみstoreに保存してあるスクロール位置まで自動でスクロール