### PR TITLE
カメラ検索の改善

### DIFF
--- a/app/javascript/packs/components/CameraSearch.jsx
+++ b/app/javascript/packs/components/CameraSearch.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback } from "react";
+import React, { useRef, useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import Webcam from "react-webcam";
 import { BallTriangle } from "react-loader-spinner";
@@ -31,6 +31,21 @@ const CameraSearch = () => {
       display.classList.add("display-none");
     }
   }
+
+  const stopEvent = (event) => {
+    event.preventDefault();
+  }
+
+  useEffect(() => {
+    if (isCaptureEnable || imageData) {
+      window.addEventListener("wheel", stopEvent, { passive: false });
+      window.addEventListener("touchmove", stopEvent, { passive: false });
+    }
+    return () => {
+      window.removeEventListener("wheel", stopEvent, { passive: false });
+      window.removeEventListener("touchmove", stopEvent, { passive: false });
+    }
+  }, [isCaptureEnable, imageData]);
 
   const navigate = useNavigate();
   const [progress, setProgress] = useState(false);
@@ -153,7 +168,7 @@ const CameraSearch = () => {
             screenshotFormat="image/jpeg"
             width="100%"
             videoConstraints={{
-              aspectRatio: (window.innerHeight - 108) / window.innerWidth,
+              aspectRatio: isPC() ? (414 / (window.innerHeight - 108)) : ((window.innerHeight - 108) / window.innerWidth),
               facingMode: isPC() ? "user" : { exact: "environment" }
               // width: { min: 640, ideal: 1170, max: 1284 },
               // height: { min: 1136, ideal: 2532, max: 2778 }

--- a/app/javascript/packs/components/CameraSearch.jsx
+++ b/app/javascript/packs/components/CameraSearch.jsx
@@ -85,7 +85,11 @@ const CameraSearch = () => {
       } else {
         navigate("/beers/no_search_result");
       }
+      // 検索結果が現在のページと同じ場合以下の処理が必要
+      displayShow(true);
       setProgress(false);
+      setCaptureEnable(false);
+      setImageData(null);
     } catch (error) {
       console.log(error);
       setProgress(false);


### PR DESCRIPTION
- PCでカメラ起動時の撮影画面サイズを修正
- カメラ起動時はスクロールできないようにJSでイベント制御
- 検索結果が現在と同じページになる場合のバグ修正